### PR TITLE
Make the game count turns and add a simple wait action

### DIFF
--- a/Assets/tiny_rogue/Scripts/Systems/GameStateSystem.cs
+++ b/Assets/tiny_rogue/Scripts/Systems/GameStateSystem.cs
@@ -28,8 +28,10 @@ namespace game
 
         eGameState _state = eGameState.Startup;
         View _view = new View();
+        TurnManager _turnManager = new TurnManager();
 
         public View View => _view;
+        public TurnManager TurnManager => _turnManager;
 
         private bool TryGenerateViewport()
         {
@@ -155,6 +157,7 @@ namespace game
                     if (input.GetKeyDown(KeyCode.Space))
                     {
                         GenerateLevel();
+                        TurnManager.ResetTurnCount();
                         _state = eGameState.InGame;
                     }
                 } break;
@@ -162,6 +165,10 @@ namespace game
                 {
                     var sbs = World.GetOrCreateSystem<StatusBarSystem>();
                     sbs.OnUpdateManual(EntityManager, PostUpdateCommands);  
+                    
+                    if(TurnManager.NeedToTickTurn)
+                        TurnManager.OnTurn();
+                    
                 } break;
             }
         }

--- a/Assets/tiny_rogue/Scripts/Systems/InputMoveSystem.cs
+++ b/Assets/tiny_rogue/Scripts/Systems/InputMoveSystem.cs
@@ -1,10 +1,11 @@
+using System;
 using Unity.Collections;
 using Unity.Entities;
 using Unity.Mathematics;
 using Unity.Tiny.Core;
 using Unity.Tiny.Core2D;
-using Unity.Tiny.Input;
-
+using UnityEngine;
+using KeyCode = Unity.Tiny.Input.KeyCode;
 #if !UNITY_WEBGL
 using InputSystem = Unity.Tiny.GLFW.GLFWInputSystem;
 #else
@@ -19,7 +20,9 @@ namespace game
         {
             Entities.WithAll<MoveWithInput>().ForEach((Entity player, ref WorldCoord coord, ref Translation translation) =>
             {
+                var gss = EntityManager.World.GetExistingSystem<GameStateSystem>();
                 var input = EntityManager.World.GetExistingSystem<InputSystem>();
+                var turnManager = gss.TurnManager;
 
                 var x = coord.x;
                 var y = coord.y;
@@ -31,7 +34,12 @@ namespace game
                 if(input.GetKeyDown(KeyCode.D) || input.GetKeyDown(KeyCode.RightArrow))
                     x = x + 1;
                 if(input.GetKeyDown(KeyCode.A) || input.GetKeyDown(KeyCode.LeftArrow))
-                    x = x - 1;     
+                    x = x - 1;
+                if (input.GetKeyDown(KeyCode.Space))
+                {
+                    Debug.Log("Wait");
+                    turnManager.NeedToTickTurn = true;
+                }
 
                 Entities.WithNone<BlockMovement>().WithAll<Tile>().ForEach((ref WorldCoord tileCoord, ref Translation tileTrans) =>
                 {
@@ -40,6 +48,7 @@ namespace game
                     {
                         EntityManager.SetComponentData(player, tileCoord);
                         EntityManager.SetComponentData(player, tileTrans);
+                        turnManager.NeedToTickTurn = true;
                     }
                 });
             });

--- a/Assets/tiny_rogue/Scripts/Systems/TurnSystem.cs
+++ b/Assets/tiny_rogue/Scripts/Systems/TurnSystem.cs
@@ -1,0 +1,14 @@
+using Unity.Entities;
+
+namespace game
+{
+    public abstract class TurnSystem : ComponentSystem
+    {
+        public TurnSystem()
+        {
+            TurnManager.RegisterSystem(this);
+        }
+
+        public abstract void OnTurn(uint turnNumber);
+    }
+}

--- a/Assets/tiny_rogue/Scripts/Systems/TurnSystem.cs.meta
+++ b/Assets/tiny_rogue/Scripts/Systems/TurnSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 15a987b205f804afb9538198b17b0bc6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/tiny_rogue/Scripts/TurnManager.cs
+++ b/Assets/tiny_rogue/Scripts/TurnManager.cs
@@ -1,0 +1,38 @@
+using Unity.Entities;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine.Assertions;
+
+namespace game
+{
+    public class TurnManager
+    {
+        static List<TurnSystem> _turnSystems = new List<TurnSystem>();
+        uint _turnCount = 0;
+        public uint TurnCount => _turnCount;
+        public bool NeedToTickTurn { get; set; }
+
+        public void ResetTurnCount()
+        {
+            _turnCount = 0;
+        }
+        
+        public static void RegisterSystem(TurnSystem system)
+        {
+#if DEBUG
+            Assert.IsFalse(_turnSystems.Contains(system), "Trying to add a system to the turn manager more than once.");
+#endif
+            _turnSystems.Add(system);   
+        }
+
+        public void OnTurn()
+        {
+            for (int i = 0; i < _turnSystems.Count; i++)
+            {
+                TurnManager._turnSystems[i].OnTurn(_turnCount);
+            }
+            _turnCount++;
+            NeedToTickTurn = false;
+        }
+    }
+}

--- a/Assets/tiny_rogue/Scripts/TurnManager.cs.meta
+++ b/Assets/tiny_rogue/Scripts/TurnManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a8b1814edee1c4b34aa79c8fe414eb2a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
KeyCode.Period does not seem to get detected on Mac. So that's something to bring up with the Tiny devs.

In the meantime I've made the new Wait action occur when space is pressed.
Moving or waiting passes one turn.
I'm implementing this now because I need it to implement the log which is a feature we want before hackweek begins.

I've added the turn system in a simple direct way. I could see it being replaced by something more general or ECS-friendly in the future.